### PR TITLE
Add compatibility with other plugins

### DIFF
--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -64,13 +64,17 @@ function! s:MapPairToPattern(_, pair)
   return fullPattern
 endfunction
 
+function! s:SetupKeyMappings()
+  inoremap <CR> <Plug>ExpanderOnenterpressed;
+  inoremap <script> <expr> <Plug>ExpanderOnenterpressed; <SID>OnEnterPressed()
+endfunction
+
 function! s:Initialize()
   let s:patternsToExpand = mapnew(
     \ s:pairsToExpand,
     \ funcref("s:MapPairToPattern")
     \ )
-  inoremap <CR> <Plug>ExpanderOnenterpressed;
-  inoremap <script> <expr> <Plug>ExpanderOnenterpressed; <SID>OnEnterPressed()
+  call s:SetupKeyMappings()
 endfunction
 
 call s:Initialize()

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -56,8 +56,8 @@ endfunction
 
 function! <SID>OnEnterPressed()
   if !g:isExpanderEnabled || !s:IsCursorBetweenPair()
-    let unchangedKey = "\n"
-    return unchangedKey
+    let enterKeyMappingText = "\<CR>"
+    return enterKeyMappingText
   endif
   call s:InsertExpansionText()
   let noKey = ""

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -35,14 +35,8 @@ function! s:GetKeysToPressForExpansion()
   " Keys for: new line, new undo checkpoint, balance delimiter indents, add
   " line in between, balance indent:
   let keysToPress = "\<CR>\<C-g>u0\<C-d>" .. outsideIndentInKeys
-    \  .. "\<C-o>\<S-o>0\<C-d>" .. outsideIndentInKeys .. oneIndentLevel
+    \ .. "\<C-o>\<S-o>0\<C-d>" .. outsideIndentInKeys .. oneIndentLevel
   return keysToPress
-endfunction
-
-function! s:InsertExpansionText()
-  let keysToPress = s:GetKeysToPressForExpansion()
-  let flags = "in"
-  call feedkeys(keysToPress, flags)
 endfunction
 
 function! s:IsPatternOnBuffer(_, pattern)
@@ -59,9 +53,8 @@ function! <SID>OnEnterPressed()
     let enterKeyMappingText = "\<CR>"
     return enterKeyMappingText
   endif
-  call s:InsertExpansionText()
-  let noKey = ""
-  return noKey
+  let expansionKeys = s:GetKeysToPressForExpansion()
+  return expansionKeys
 endfunction
 
 function! s:MapPairToPattern(_, pair)

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -65,7 +65,7 @@ function! s:MapPairToPattern(_, pair)
 endfunction
 
 function! s:SetupKeyMappings()
-  inoremap <CR> <Plug>ExpanderOnenterpressed;
+  inoremap <unique> <CR> <Plug>ExpanderOnenterpressed;
   inoremap <script> <expr> <Plug>ExpanderOnenterpressed; <SID>OnEnterPressed()
 endfunction
 

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -1,5 +1,5 @@
 " Plugin that expands new lines between brackets and XML-like tags.
-" Last Change: 2023 September 22
+" Last Change: 2023 September 23
 " Maintainer: Victor S.
 " License: This file is placed in the public domain.
 

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -69,7 +69,8 @@ function! s:Initialize()
     \ s:pairsToExpand,
     \ funcref("s:MapPairToPattern")
     \ )
-  inoremap <expr> <CR> <SID>OnEnterPressed()
+  inoremap <CR> <Plug>ExpanderOnenterpressed;
+  inoremap <script> <expr> <Plug>ExpanderOnenterpressed; <SID>OnEnterPressed()
 endfunction
 
 call s:Initialize()


### PR DESCRIPTION
Changed the mapping definition to only define a mapping for the enter key if there is not already one.
This adds compatibility with other plugins, possibly through an adapter.
Closes #1.