### PR TITLE
feat: add support for expanding custom patterns

### DIFF
--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -69,11 +69,13 @@ function! s:SetupKeyMappings()
   inoremap <script> <expr> <Plug>ExpanderOnenterpressed; <SID>OnEnterPressed()
 endfunction
 
+function! s:GetPatternsToExpandFromPairs(pairs)
+  let patterns = mapnew(a:pairs, funcref("s:MapPairToPattern"))
+  return patterns
+endfunction
+
 function! s:Initialize()
-  let s:patternsToExpand = mapnew(
-    \ s:pairsToExpand,
-    \ funcref("s:MapPairToPattern")
-    \ )
+  let s:patternsToExpand = s:GetPatternsToExpandFromPairs(s:pairsToExpand)
   call s:SetupKeyMappings()
 endfunction
 

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -11,7 +11,7 @@ let g:isExpanderEnabled = 1
 let s:maxTagNameLength = 30
 let s:maxTagAttributeLength = 200
 " Pairs of patterns that describe the opening and closing elements:
-let s:pairsToExpand = [
+let s:defaultPairsToExpand = [
   \ ["(", ")"],
   \ ["[[]", "[]]"],
   \ ["{", "}"],
@@ -75,7 +75,9 @@ function! s:GetPatternsToExpandFromPairs(pairs)
 endfunction
 
 function! s:Initialize()
-  let s:patternsToExpand = s:GetPatternsToExpandFromPairs(s:pairsToExpand)
+  let s:patternsToExpand = s:GetPatternsToExpandFromPairs(
+    \ s:defaultPairsToExpand
+    \ )
   call s:SetupKeyMappings()
 endfunction
 

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -76,7 +76,7 @@ endfunction
 
 function! s:Initialize()
   let s:patternsToExpand = s:GetPatternsToExpandFromPairs(
-    \ s:defaultPairsToExpand
+    \ s:defaultPairsToExpand + get(g:, "ExpanderCustomPairs", [])
     \ )
   call s:SetupKeyMappings()
 endfunction

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -1,5 +1,5 @@
 " Plugin that expands new lines between brackets and XML-like tags.
-" Last Change: 2023 September 23
+" Last Change: 2023 September 26
 " Maintainer: Victor S.
 " License: This file is placed in the public domain.
 

--- a/plugin/expander.vim
+++ b/plugin/expander.vim
@@ -65,7 +65,7 @@ function! s:MapPairToPattern(_, pair)
 endfunction
 
 function! s:SetupKeyMappings()
-  inoremap <unique> <CR> <Plug>ExpanderOnenterpressed;
+  silent! inoremap <unique> <CR> <Plug>ExpanderOnenterpressed;
   inoremap <script> <expr> <Plug>ExpanderOnenterpressed; <SID>OnEnterPressed()
 endfunction
 


### PR DESCRIPTION
Added support for expanding custom pairs defined by the user through the global variable `g:ExpanderCustomPairs`. The variable is a list containing a list of the opening and closing element as strings for each custom pair.
Closes #5.